### PR TITLE
Add Android NDK 28+ compatibility fixes

### DIFF
--- a/libxhook/jni/Application.mk
+++ b/libxhook/jni/Application.mk
@@ -1,2 +1,2 @@
-APP_ABI      := armeabi armeabi-v7a arm64-v8a x86 x86_64
+APP_ABI      := armeabi-v7a arm64-v8a x86 x86_64
 APP_PLATFORM := android-14

--- a/libxhook/jni/xh_util.c
+++ b/libxhook/jni/xh_util.c
@@ -37,8 +37,22 @@
 #include "xh_errno.h"
 #include "xh_log.h"
 
-#define PAGE_START(addr) ((addr) & PAGE_MASK)
-#define PAGE_END(addr)   (PAGE_START(addr + sizeof(uintptr_t) - 1) + PAGE_SIZE)
+// NDK 28+ no longer defines PAGE_SIZE and PAGE_MASK by default
+// Use runtime functions for flexible page size support
+static inline size_t get_page_size(void) {
+    static size_t page_size = 0;
+    if (page_size == 0) {
+        page_size = sysconf(_SC_PAGESIZE);
+    }
+    return page_size;
+}
+
+static inline uintptr_t get_page_mask(void) {
+    return ~(get_page_size() - 1);
+}
+
+#define PAGE_START(addr) ((addr) & get_page_mask())
+#define PAGE_END(addr)   (PAGE_START(addr + sizeof(uintptr_t) - 1) + get_page_size())
 #define PAGE_COVER(addr) (PAGE_END(addr) - PAGE_START(addr))
 
 int xh_util_get_mem_protect(uintptr_t addr, size_t len, const char *pathname, unsigned int *prot)


### PR DESCRIPTION
Essential changes:
- Fix PAGE_SIZE/PAGE_MASK undefined errors in NDK 28+
- Replace compile-time constants with runtime functions for flexible page size support
- Support both 4KB and 16KB page sizes as required by Android 15+

Minimal build changes:
- Remove deprecated armeabi ABI (NDK 28 no longer supports it)
- Keep android-14 platform (NDK automatically upgrades to android-21)

Technical implementation:
- Add get_page_size() and get_page_mask() runtime functions in xh_util.c
- Use sysconf(_SC_PAGESIZE) for runtime page size detection

Tested with NDK 28.2.13676358 - all architectures build successfully.